### PR TITLE
Add config object and window title with current tab directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,13 +23,19 @@ const colors = {
   lightWhite: '#E5E5E5'
 }
 
-exports.decorateConfig = config => Object.assign({}, config, {
-  padding: '7px 7px',
-  backgroundColor: '#fff',
-  foregroundColor: '#000',
-  css: (config.css || '') + styles,
-  colors
-})
+exports.decorateConfig = config => {
+  const isDarkMode = config.hyperNative && config.hyperNative.darkMode
+
+  const hyperNativeConfig = Object.assign({
+    padding: '7px 7px',
+    backgroundColor: isDarkMode ? '#000' : '#fff',
+    foregroundColor: isDarkMode ? '#fff' : '#000',
+    css: (config.css || '') + styles,
+    colors
+  }, config.hyperNative)
+
+  return Object.assign({}, config, hyperNativeConfig)
+}
 
 exports.decorateBrowserOptions = defaults => Object.assign({}, defaults, {
   titleBarStyle: 'default',

--- a/index.js
+++ b/index.js
@@ -53,3 +53,25 @@ exports.getTabsProps = (parentProps, props) => {
 
   return Object.assign({}, parentProps, props)
 }
+
+exports.decorateTab = (Tab, {React}) => {
+  return class extends Tab {
+    render() {
+      if (this.props.isActive === true) {
+        document.title = this.props.text
+      }
+      return React.createElement(Tab, Object.assign({}, this.props, {}))
+    }
+  }
+}
+
+exports.decorateTabs = (Tabs, {React}) => {
+  return class extends Tabs {
+    render() {
+      if (this.props.tabs.length === 1 && typeof this.props.tabs[0].title === 'string') {
+        document.title = this.props.tabs[0].title
+      }
+      return React.createElement(Tabs, Object.assign({}, this.props, {}))
+    }
+  }
+}

--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,36 @@ plugins: [
 ]
 ```
 
+## Config
+
+Add following to `~/.hyper.js` in the `config` section:
+
+```js
+hyperNative: {
+  darkMode: true, // Can enable or disable Dark mode. The value value is 'false'
+  colors: { // Can customize the colors
+    black: "#000000",
+    red: "#ab1500",
+    green: "#39fd35",
+    yellow: "#a9a600",
+    blue: "#36a5fc",
+    magenta: "#c12dbf",
+    cyan: "#00b3bf",
+    white: "#cacaca",
+    lightBlack: "#797979",
+    lightRed: "#ec2100",
+    lightGreen: "#00db00",
+    lightYellow: "#eae600",
+    lightBlue: "#36a5fc",
+    lightMagenta: "#ec3aea",
+    lightCyan: "#00e8ea",
+    lightWhite: "#eaeaea",
+  },
+  backgroundColor: '#fff' // If omitted, it will use 'darkMode' property to define it as '#fff' or '#000'
+  foregroundColor: '#000' // If omitted, it will use 'darkMode' property to define it as '#000' or '#fff'
+}
+```
+
 ## Contribute
 
 1. [Fork](https://help.github.com/articles/fork-a-repo/) this repository to your own GitHub account and then [clone](https://help.github.com/articles/cloning-a-repository/) it to your local device (make sure that it's located in `~/.hyper-plugins/local`)


### PR DESCRIPTION
Hi,

I made this PR with changes I made locally to your (awesome, btw) theme to be able to configure the colors from the config file (I like the terminal with a black background and some specific color setup). 

I also have added a feature that can update the terminal window title with current tab directly, so if you have a lot of tabs opened (like I normally have), you can still see the current directory easily in the title bar.

I hope you like the changes.

If you have any question or suggestion, please let me know. 

Thank you !

Regards,